### PR TITLE
Add a simple control for heatpump, FMU and sensors for heat demand/supply

### DIFF
--- a/district_model/modelica/Q100_DistrictModel/Components.mo
+++ b/district_model/modelica/Q100_DistrictModel/Components.mo
@@ -389,15 +389,15 @@ Parameter:
         Line(points = {{-160, 100}, {-100, 100}, {-100, 66.2}, {-80, 66.2}}, color = {0, 0, 127}));
       connect(u_dotm_source, fluidSource.dotm) annotation (
         Line(points = {{-160, 60}, {-82, 60}, {-82, 59.4}, {-80, 59.4}}, color = {0, 0, 127}));
-    connect(fluidSource.enthalpyPort_b, heatPump.enthalpyPort_a1) annotation (
+    connect(fluidSource.enthalpyPort_b,heatPump.enthalpyPort_a2)  annotation (
         Line(points={{-62,63},{-44,63},{-44,64},{-16,64},{-16,42}}, color={176,
             0,0}));
-    connect(vessel.enthalpyPort_a, heatPump.enthalpyPort_b1) annotation (Line(
+    connect(vessel.enthalpyPort_a,heatPump.enthalpyPort_b2)  annotation (Line(
           points={{-59,6},{-16,6},{-16,15.3334}}, color={176,0,0}));
-    connect(TemperatureOutput.enthalpyPort_a, heatPump.enthalpyPort_b)
+    connect(TemperatureOutput.enthalpyPort_a, heatPump.enthalpyPort_b1)
       annotation (Line(points={{-0.1,89.2},{-0.1,65.6},{0,65.6},{0,42}}, color=
             {176,0,0}));
-    connect(heatPump.enthalpyPort_a, TemperatureInput.enthalpyPort_b)
+    connect(heatPump.enthalpyPort_a1, TemperatureInput.enthalpyPort_b)
       annotation (Line(points={{0,15.3334},{0,-49},{-0.1,-49}}, color={176,0,0}));
       annotation (
         Documentation(info = "<html>
@@ -693,8 +693,9 @@ Parameter:
       Modelica.Blocks.Math.Division division annotation (
         Placement(visible = true, transformation(extent = {{-20, 0}, {0, 20}}, rotation = 0)));
       Modelica.Blocks.Math.Min min annotation (
-        Placement(visible = true, transformation(origin = {70, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
-      Modelica.Blocks.Sources.Constant const2(k = 1) annotation (
+        Placement(visible = true, transformation(origin={72,0},    extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+      Modelica.Blocks.Sources.Constant const2(k=0.99)
+                                                     annotation (
         Placement(visible = true, transformation(extent = {{20, -40}, {40, -20}}, rotation = 0)));
       Modelica.Blocks.Interfaces.RealInput u_deltaT_setpoint annotation (
         Placement(visible = true, transformation(origin = {-28, 120}, extent = {{-20, -20}, {20, 20}}, rotation = 270), iconTransformation(origin = {0, 120}, extent = {{-20, -20}, {20, 20}}, rotation = 270)));
@@ -714,11 +715,11 @@ Parameter:
       connect(const3.y, max1.u2) annotation (
         Line(points = {{-61, -20}, {-70, -20}, {-70, 10}, {-62, 10}}, color = {0, 0, 127}));
       connect(min.y, y_Qdot) annotation (
-        Line(points = {{81, 0}, {110, 0}}, color = {0, 0, 127}));
+        Line(points={{83,0},{110,0}},      color = {0, 0, 127}));
       connect(division.y, min.u1) annotation (
-        Line(points = {{1, 10}, {28, 10}, {28, 6}, {58, 6}}, color = {0, 0, 127}));
+        Line(points={{1,10},{28,10},{28,6},{60,6}},          color = {0, 0, 127}));
       connect(const2.y, min.u2) annotation (
-        Line(points = {{41, -30}, {50, -30}, {50, -6}, {58, -6}}, color = {0, 0, 127}));
+        Line(points={{41,-30},{50,-30},{50,-6},{60,-6}},          color = {0, 0, 127}));
       connect(division.u2, u_deltaT_setpoint) annotation (
         Line(points = {{-22, 4}, {-28, 4}, {-28, 120}}, color = {0, 0, 127}));
       annotation (

--- a/district_model/modelica/Q100_DistrictModel/Data.mo
+++ b/district_model/modelica/Q100_DistrictModel/Data.mo
@@ -31,8 +31,8 @@ package Data
         Pfad = "Z:/owncloud/Consolinno/Projekte/Quarree100_Consolinno/Simulation_Modelica/input/");
     end inputData_jwalbrunn;
 
-    record WP_55kW
-      extends AixLib.DataBase.HeatPump.HeatPumpBaseDataDefinition(tableP_ele = [0, -15, -10, -7, 2, 7, 10; 35, 17600, 19750, 14668, 13115, 90609, 86453; 45, 27000, 27273, 18366, 18443, 12000, 12000; 50, 28244, 25000, 17900, 16000, 12820, 10000; 55, 36152, 39009, 29800, 24980, 11842, 11000], tableQdot_con = [0, -15, -10, -7, 2, 7, 10; 35, 44000, 45250, 45180, 55480, 55000, 60000; 45, 42000, 45000, 44630, 54960, 55000, 56000; 50, 45190, 50000, 40000, 45000, 50000, 55000; 55, 45190, 43300, 45000, 50960, 45000, 55000], mFlow_conNom = 60000 / 4180 / 5, mFlow_evaNom = 1, tableUppBou = [-20, 50; -10, 60; 30, 60; 35, 55]);
+    record WP_550kW
+      extends AixLib.DataBase.HeatPump.HeatPumpBaseDataDefinition(tableP_ele = [0, -15, -10, -7, 2, 7, 10; 35, 176000, 197500, 146680, 131150, 906090, 864530; 45, 270000, 272730, 183660, 184430, 120000, 120000; 50, 282440, 250000, 179000, 160000, 128200, 100000; 55, 361520, 390090, 298000, 249800, 118420, 110000], tableQdot_con = [0, -15, -10, -7, 2, 7, 10; 35, 440000, 452500, 451800, 554800, 550000, 600000; 45, 420000, 450000, 446300, 549600, 550000, 560000; 50, 451900, 500000, 400000, 450000, 500000, 550000; 55, 451900, 433000, 450000, 509600, 450000, 550000], mFlow_conNom = 60000 / 4180 / 5, mFlow_evaNom = 1, tableUppBou = [-20, 50; -10, 60; 30, 60; 35, 55]);
       annotation (
         Icon(coordinateSystem(preserveAspectRatio = false)),
         Diagram(coordinateSystem(preserveAspectRatio = false)),
@@ -49,7 +49,7 @@ First implementation (see issue <a href=
 </li>
 </ul>
 </html>"));
-    end WP_55kW;
+    end WP_550kW;
 
     record HeatDemand
       extends AixLib.DataBase.HeatPump.HeatPumpBaseDataDefinition(tableP_ele = [0, -15, -10, -7, 2, 7, 10; 35, 17600, 19750, 14668, 13115, 90609, 86453; 45, 27000, 27273, 18366, 18443, 12000, 12000; 50, 28244, 25000, 17900, 16000, 12820, 10000; 55, 36152, 39009, 29800, 24980, 11842, 11000], tableQdot_con = [0, -15, -10, -7, 2, 7, 10; 35, 44000, 45250, 45180, 55480, 55000, 60000; 45, 42000, 45000, 44630, 54960, 55000, 56000; 50, 45190, 50000, 40000, 45000, 50000, 55000; 55, 45190, 43300, 45000, 50960, 45000, 55000], mFlow_conNom = 60000 / 4180 / 5, mFlow_evaNom = 1, tableUppBou = [-20, 50; -10, 60; 30, 60; 35, 55]);

--- a/district_model/modelica/Q100_DistrictModel/FMUs.mo
+++ b/district_model/modelica/Q100_DistrictModel/FMUs.mo
@@ -240,10 +240,10 @@ package FMUs
     AixLib.FastHVAC.Components.HeatGenerators.HeatPump.HeatPump heatPump(
       redeclare model PerDataHea =
           AixLib.DataBase.HeatPump.PerformanceData.LookUpTable2D (dataTable=
-              Q100_DistrictModel.Data.WP_55kW()),
+              Q100_DistrictModel.Data.WP_550kW()),
       redeclare model PerDataChi =
           AixLib.DataBase.HeatPump.PerformanceData.LookUpTable2D (dataTable=
-              Q100_DistrictModel.Data.WP_55kW()),
+              Q100_DistrictModel.Data.WP_550kW()),
       CCon=100,
       CEva=100,
       GCon=5,
@@ -271,7 +271,7 @@ package FMUs
           origin={-1468,770})));
     AixLib.FastHVAC.Components.Sensors.TemperatureSensor temperature_TRC_2204
       annotation (Placement(visible=true, transformation(
-          origin={-1310,800},
+          origin={-1348,800},
           extent={{-10,-10},{10,10}},
           rotation=0)));
     Modelica.Blocks.Sources.BooleanConstant booleanConstant
@@ -289,7 +289,7 @@ package FMUs
     Modelica.Blocks.Sources.Constant const10(k=1)  annotation (
       Placement(visible = true, transformation(origin={-1510,770},   extent={{-10,-10},
               {10,10}},                                                                               rotation = 0)));
-    Modelica.Blocks.Sources.Constant const11(k=2)  annotation (
+    Modelica.Blocks.Sources.Constant const11(k=20) annotation (
       Placement(visible = true, transformation(origin={-1570,770},   extent={{-10,-10},
               {10,10}},                                                                               rotation = 0)));
     AixLib.FastHVAC.Components.Valves.ThreeWayValve threeWayValve_NS_8106
@@ -408,7 +408,7 @@ package FMUs
           transformation(
           extent={{10,10},{-10,-10}},
           rotation=180,
-          origin={-1320,760})));
+          origin={-1330,760})));
     Modelica.Blocks.Sources.Constant const19(k=70 + 273.15)
                                                    annotation (
       Placement(visible = true, transformation(origin={-1412,766},   extent={{-10,-10},
@@ -423,10 +423,6 @@ package FMUs
       Placement(visible = true, transformation(origin={880,660}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
     Modelica.Blocks.Math.Add add(k1=-1)
       annotation (Placement(transformation(extent={{760,690},{740,710}})));
-    Modelica.Blocks.Sources.Constant const5(k=15 + 273.15)
-                                                   annotation (
-      Placement(visible = true, transformation(origin={-1590,804},   extent={{-10,-10},
-              {10,10}},                                                                               rotation = 0)));
     AixLib.FastHVAC.Components.Sensors.MassFlowSensor massFlowRate4
                                                                    annotation (
         Placement(transformation(
@@ -3456,7 +3452,7 @@ package FMUs
     Components.RealOutput_JW y_TRC_2202=temperature_TRC_2202.T - 273.15
       annotation (Placement(transformation(extent={{-1374,746},{-1386,758}})));
     Components.RealOutput_JW y_TRC_2204=temperature_TRC_2204.T - 273.15
-      annotation (Placement(transformation(extent={{-1312,808},{-1324,820}})));
+      annotation (Placement(transformation(extent={{-1350,808},{-1362,820}})));
     Components.RealOutput_JW y_TRC_2213=temperature_TRC_2213.T - 273.15
       annotation (Placement(transformation(extent={{-1186,748},{-1198,760}})));
     Components.RealOutput_JW y_TRC_2216=temperature_TRC_2216.T - 273.15
@@ -3541,6 +3537,37 @@ package FMUs
           extent={{6,-6},{-6,6}},
           rotation=0,
           origin={-34,254})));
+    Modelica.Blocks.Math.Add add1(k1=-1)
+      annotation (Placement(transformation(extent={{-80,174},{-60,194}})));
+    Modelica.Blocks.Math.Gain gain(k=4187/1000)
+      annotation (Placement(transformation(extent={{0,180},{20,200}})));
+    Modelica.Blocks.Math.Product product
+      annotation (Placement(transformation(extent={{-40,180},{-20,200}})));
+    Components.RealOutput_JW y_WMZ_Heizzentrale
+      annotation (Placement(transformation(extent={{40,184},{52,196}})));
+    Components.RealOutput_JW y_WMZ_Haus = sink.Load / 1000
+      annotation (Placement(transformation(extent={{834,674},{846,686}})));
+    Modelica.Blocks.Sources.Sine sineGeo_T_amb1(
+      amplitude=15,
+      freqHz=1/(3600*24*365*2),
+      offset=3 + 273.15)                                                                                                annotation (
+      Placement(visible = true, transformation(origin={-1570,804},   extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+    Modelica.Blocks.Logical.Switch switch1 annotation (Placement(transformation(
+          extent={{-10,-10},{10,10}},
+          rotation=90,
+          origin={-1466,700})));
+    Modelica.Blocks.Sources.Constant const5(k=0)   annotation (
+      Placement(visible = true, transformation(origin={-1430,680},   extent={{10,-10},
+              {-10,10}},                                                                              rotation = 0)));
+    Modelica.Blocks.Logical.Hysteresis hysteresis(
+      uLow=-60,
+      uHigh=-55,
+      pre_y_start=true)
+      annotation (Placement(transformation(extent={{-1390,650},{-1410,670}})));
+    Modelica.Blocks.Math.Gain gain3(k=-1) annotation (Placement(transformation(
+          extent={{-10,-10},{10,10}},
+          rotation=270,
+          origin={-1382,690})));
   equation
     connect(dynamicPipe_HeatGrid_RF.enthalpyPort_b1, dynamicPipe_HeatStorage_unload_RF.enthalpyPort_a1) annotation (
       Line(points={{380.2,240},{179.8,240}},      color={0,128,255}));
@@ -3651,15 +3678,15 @@ package FMUs
     connect(const18.y, threeWayValve_NS_2211.opening) annotation (Line(points={{-1247,
             710},{-1240,710},{-1240,731}}, color={0,0,127}));
     connect(calc_mdot_production1.u_TemperatureInput, temperature_TRC_2202.T)
-      annotation (Line(points={{-1332,754},{-1368,754},{-1368,751},{-1369,751}},
+      annotation (Line(points={{-1342,754},{-1368,754},{-1368,751},{-1369,751}},
           color={0,0,127}));
-    connect(calc_mdot_production1.u_dotQ, heatpump_dotQ) annotation (Line(points={{-1320,
-            772},{-1320,780},{-1450,780}},        color={0,0,127}));
+    connect(calc_mdot_production1.u_dotQ, heatpump_dotQ) annotation (Line(points={{-1330,
+            772},{-1330,780},{-1450,780}},        color={0,0,127}));
     connect(const19.y, calc_mdot_production1.u_TemperatureOutput) annotation (
-        Line(points={{-1401,766},{-1368,766},{-1368,765.8},{-1332,765.8}}, color={
+        Line(points={{-1401,766},{-1368,766},{-1368,765.8},{-1342,765.8}}, color={
             0,0,127}));
     connect(calc_mdot_production1.y_mdot, pump_UP_2205.dotm_setValue) annotation (
-       Line(points={{-1309,760},{-1300,760},{-1300,748}}, color={0,0,127}));
+       Line(points={{-1319,760},{-1300,760},{-1300,748}}, color={0,0,127}));
     connect(TemperatureInput.enthalpyPort_b, sink.enthalpyPort_a1) annotation (
         Line(points={{729,659.9},{814.5,659.9},{814.5,660},{809.2,660}}, color={176,
             0,0}));
@@ -3681,8 +3708,6 @@ package FMUs
     connect(TemperatureOutput.enthalpyPort_b, dynamicPipe_HeatGrid_RF.enthalpyPort_a1)
       annotation (Line(points={{889,659.9},{900,659.9},{900,600},{680,600},{680,240},
             {399.8,240}}, color={0,128,255}));
-    connect(const5.y, fluidSource3.T_fluid) annotation (Line(points={{-1579,804},{
-            -1538,804},{-1538,804.2}},               color={0,0,127}));
     connect(dynamicPipe_HeatGrid_FF.enthalpyPort_b1, TemperatureInput.enthalpyPort_a)
       annotation (Line(points={{399.8,300},{620,300},{620,659.9},{711.2,659.9}},
           color={176,0,0}));
@@ -4028,30 +4053,18 @@ package FMUs
       dynamicPipe_HeatStorage_unload_FF48.enthalpyPort_a1) annotation (Line(
           points={{-1377,739.9},{-1398.6,739.9},{-1398.6,740},{-1420.2,740}},
           color={0,128,255}));
-    connect(dynamicPipe_HeatStorage_unload_FF48.enthalpyPort_b1, heatPump.enthalpyPort_a)
-      annotation (Line(points={{-1439.8,740},{-1461,740},{-1461,758}}, color={0,128,
-            255}));
     connect(vessel3.enthalpyPort_a, dynamicPipe_HeatStorage_unload_FF49.enthalpyPort_b1)
       annotation (Line(points={{-1539,740},{-1521.8,740}}, color={176,0,0}));
-    connect(dynamicPipe_HeatStorage_unload_FF49.enthalpyPort_a1, heatPump.enthalpyPort_b1)
-      annotation (Line(points={{-1502.2,740},{-1475,740},{-1475,758}}, color={176,
-            0,0}));
     connect(fluidSource3.enthalpyPort_b, dynamicPipe_HeatStorage_unload_FF50.enthalpyPort_a1)
       annotation (Line(points={{-1520,801},{-1515.9,801},{-1515.9,800},{-1503.8,800}},
           color={176,0,0}));
-    connect(dynamicPipe_HeatStorage_unload_FF50.enthalpyPort_b1, heatPump.enthalpyPort_a1)
-      annotation (Line(points={{-1484.2,800},{-1475,800},{-1475,782}}, color={176,
-            0,0}));
     connect(temperature_TRC_2204.enthalpyPort_a,
       dynamicPipe_HeatStorage_unload_FF51.enthalpyPort_b1) annotation (Line(
-          points={{-1318.8,799.9},{-1354.5,799.9},{-1354.5,800},{-1420.2,800}},
+          points={{-1356.8,799.9},{-1354.5,799.9},{-1354.5,800},{-1420.2,800}},
           color={176,0,0}));
-    connect(dynamicPipe_HeatStorage_unload_FF51.enthalpyPort_a1, heatPump.enthalpyPort_b)
-      annotation (Line(points={{-1439.8,800},{-1461,800},{-1461,782}}, color={176,
-            0,0}));
     connect(temperature_TRC_2204.enthalpyPort_b,
       dynamicPipe_HeatStorage_unload_FF52.enthalpyPort_a1) annotation (Line(
-          points={{-1301,799.9},{-1289.5,799.9},{-1289.5,800},{-1279.8,800}},
+          points={{-1339,799.9},{-1289.5,799.9},{-1289.5,800},{-1279.8,800}},
           color={176,0,0}));
     connect(dynamicPipe_HeatStorage_unload_FF52.enthalpyPort_b1, manifold_NS_2211.enthalpyPort_a[
       1]) annotation (Line(points={{-1260.2,800},{-1250,800},{-1250,800.5},{-1240,
@@ -4086,13 +4099,48 @@ package FMUs
           color={176,0,0}));
     connect(u_boiler_0_1, max.u1) annotation (Line(points={{-1620,140},{-1412,140},
             {-1412,92},{-1402,92}}, color={0,0,127}));
-    connect(heatPump.nSet, u_heatpump_0_1) annotation (Line(points={{-1465.67,
-            756.08},{-1465.67,680},{-1620,680}},
-                                         color={0,0,127}));
     connect(u_NS_7102, min1.u2) annotation (Line(points={{-1620,570},{-710,570},{-710,
             738},{-702,738},{-702,740}}, color={0,0,127}));
     connect(u_NS_7202, min.u2)
       annotation (Line(points={{-1620,520},{-702,520}}, color={0,0,127}));
+    connect(product.y, gain.u)
+      annotation (Line(points={{-19,190},{-2,190}}, color={0,0,127}));
+    connect(y_FRC_8204, product.u1) annotation (Line(points={{-34,254},{-50,254},{
+            -50,196},{-42,196}}, color={0,0,127}));
+    connect(add1.y, product.u2)
+      annotation (Line(points={{-59,184},{-42,184}}, color={0,0,127}));
+    connect(add1.u1, y_TRC_8206) annotation (Line(points={{-82,190},{-88,190},{-88,
+            264},{6,264},{6,252}}, color={0,0,127}));
+    connect(y_TRC_8205, add1.u2) annotation (Line(points={{-10,288},{-92,288},{-92,
+            178},{-82,178}}, color={0,0,127}));
+    connect(gain.y, y_WMZ_Heizzentrale)
+      annotation (Line(points={{21,190},{46,190}}, color={0,0,127}));
+    connect(dynamicPipe_HeatStorage_unload_FF48.enthalpyPort_b1, heatPump.enthalpyPort_a)
+      annotation (Line(points={{-1439.8,740},{-1461,740},{-1461,758}}, color={0,128,
+            255}));
+    connect(dynamicPipe_HeatStorage_unload_FF51.enthalpyPort_a1, heatPump.enthalpyPort_b)
+      annotation (Line(points={{-1439.8,800},{-1461,800},{-1461,782}}, color={176,
+            0,0}));
+    connect(dynamicPipe_HeatStorage_unload_FF50.enthalpyPort_b1, heatPump.enthalpyPort_a1)
+      annotation (Line(points={{-1484.2,800},{-1475,800},{-1475,782}}, color={176,
+            0,0}));
+    connect(heatPump.enthalpyPort_b1, dynamicPipe_HeatStorage_unload_FF49.enthalpyPort_a1)
+      annotation (Line(points={{-1475,758},{-1476,758},{-1476,740},{-1502.2,740}},
+          color={176,0,0}));
+    connect(sineGeo_T_amb1.y, fluidSource3.T_fluid) annotation (Line(points={{
+            -1559,804},{-1560,804},{-1560,804.2},{-1538,804.2}}, color={0,0,127}));
+    connect(heatPump.nSet, switch1.y) annotation (Line(points={{-1465.67,756.08},
+            {-1465.67,728.04},{-1466,728.04},{-1466,711}}, color={0,0,127}));
+    connect(u_heatpump_0_1, switch1.u1) annotation (Line(points={{-1620,680},{
+            -1474,680},{-1474,688}}, color={0,0,127}));
+    connect(const5.y, switch1.u3) annotation (Line(points={{-1441,680},{-1458,
+            680},{-1458,688}}, color={0,0,127}));
+    connect(hysteresis.y, switch1.u2) annotation (Line(points={{-1411,660},{
+            -1466,660},{-1466,688}}, color={255,0,255}));
+    connect(y_TRC_2202, gain3.u) annotation (Line(points={{-1380,752},{-1382,
+            752},{-1382,702}}, color={0,0,127}));
+    connect(gain3.y, hysteresis.u) annotation (Line(points={{-1382,679},{-1382,
+            660},{-1388,660}}, color={0,0,127}));
     annotation (
       Diagram(coordinateSystem(extent={{-1600,-1000},{1000,1000}}),                          graphics={  Line(origin = {688, 520}, points = {{0, 0}})}),
       Icon(coordinateSystem(extent={{-1600,-1000},{1000,1000}})),

--- a/district_model/modelica/Q100_DistrictModel/Simulations.mo
+++ b/district_model/modelica/Q100_DistrictModel/Simulations.mo
@@ -746,23 +746,23 @@ package Simulations
     model Gesamt_Sim
       extends Modelica.Icons.Example;
 
-    Modelica.Blocks.Sources.Constant Gaskessel(k=1)
+    Modelica.Blocks.Sources.Constant Gaskessel(k=0)
       annotation (Placement(transformation(extent={{-342,140},{-322,160}})));
     Modelica.Blocks.Sources.Constant WP(k=1)
       annotation (Placement(transformation(extent={{-360,270},{-340,290}})));
     FMUs.FMU_PhyModel fMU_PhyModel
       annotation (Placement(transformation(extent={{-256,62},{4,262}})));
-    Modelica.Blocks.Sources.Constant Speicherbeladung(k=1)
+    Modelica.Blocks.Sources.Constant Speicherbeladung(k=0)
       annotation (Placement(transformation(extent={{-400,220},{-380,240}})));
-    Modelica.Blocks.Sources.Constant Speicherentladung(k=1)
+    Modelica.Blocks.Sources.Constant Speicherentladung(k=0)
       annotation (Placement(transformation(extent={{-400,180},{-380,200}})));
     equation
     connect(Gaskessel.y, fMU_PhyModel.u_boiler_0_1) annotation (Line(points={{
             -321,150},{-300,150},{-300,176},{-258,176}}, color={0,0,127}));
     connect(Speicherentladung.y, fMU_PhyModel.u_NS_7202) annotation (Line(
           points={{-379,190},{-318,190},{-318,214},{-258,214}}, color={0,0,127}));
-    connect(Speicherbeladung.y, fMU_PhyModel.u_NS_7102) annotation (Line(points
-          ={{-379,230},{-320,230},{-320,219},{-258,219}}, color={0,0,127}));
+    connect(Speicherbeladung.y, fMU_PhyModel.u_NS_7102) annotation (Line(points=
+           {{-379,230},{-320,230},{-320,219},{-258,219}}, color={0,0,127}));
     connect(WP.y, fMU_PhyModel.u_heatpump_0_1) annotation (Line(points={{-339,
             280},{-300,280},{-300,230},{-258,230}}, color={0,0,127}));
       annotation (

--- a/district_model/modelica/Q100_DistrictModel/package.mo
+++ b/district_model/modelica/Q100_DistrictModel/package.mo
@@ -3,13 +3,14 @@
 
   annotation (
     uses(Modelica(version = "3.2.3"),                            BuildingSystems,
-    AixLib(version="0.10.2")),
+    AixLib(version="0.10.7")),
     Documentation(info = "<html>
     <p>Q100_DistrictModel dient als package, in welchem alle wichtigen Komponenten und Simulationsmodelle abgelegt werden.</p>
     <p>Erstellt wurde das Modell durch die Consolinno Energy GmbH im Rahmen des Forschungsprojektes EnStadtQuarree100.</p>
     <p>Ansprechpartner für das Projekt bei Consolinno ist Fabian Eckert. Die Arbeiten in Modelica wurde durch Johannes Walbrunn durchgeführt.</p>
     <p>Consolinno Energy GmbH, Regensburg 24. März 2020</p>
     </html>"),
-  version="1",
-  conversion(from(version="", script="ConvertFromQ100_DistrictModel_.mos")));
+  version="2",
+  conversion(from(version="", script="ConvertFromQ100_DistrictModel_.mos"), from(
+        version="1", script="ConvertFromQ100_DistrictModel_1.mos")));
 end Q100_DistrictModel;


### PR DESCRIPTION
Add a simple control for heatpump to intercept an overheating due to high input temperatures. Creating FMU and switch to AixLib 0.10.7.

There is now a hysteresis that stops the heatpump operation due to high inputtemperatures. If the temperature is higher than 60 °C, the heatpump will stop its operation until the temperature is below 55 °C.

The heatpump data has been updated due to an 550 kW thermal power production. The input air temperature will variate over the year. Consequently, the performance of the heatpump (COP) will change.  